### PR TITLE
 context isolation dissabled

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,7 +41,8 @@ function createWindow() {
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      contextIsolation: false
     }
   })
 


### PR DESCRIPTION
otherwise, it throws an error :`Uncaught TypeError: window.require is not a function`